### PR TITLE
feat: enable ArangoDB operator explicitly

### DIFF
--- a/lib/resoto-helm-chart-stack.ts
+++ b/lib/resoto-helm-chart-stack.ts
@@ -73,6 +73,8 @@ export class ResotoHelmChartAddOn implements ClusterAddOn {
                 image: {
                     tag: cfnTag.valueAsString,
                 },
+                // Enable the ArangoDB operator
+                arangodb: { operator: { enabled: true } },
                 resotocore: {
                     // Create a public reachable endpoint for the resoto service
                     service: {type: 'LoadBalancer'},


### PR DESCRIPTION
Make the CDK stack forward compatible with Resoto helm chart >= 0.7.0